### PR TITLE
- version bumped up to `1.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ## yyyy-mm-dd
+
+## 2021-01-04
+## Fixed
+- `@types/node` moved from `dependencies` to `devDependencies`. [@bulletinmybeard](https://github.com/bulletinmybeard)
+
+## 2021-01-03
+## Added
+- Terraform CLI wrapper added. [@bulletinmybeard](https://github.com/bulletinmybeard)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NTCW (Node Terraform CLI Wrapper)
 
 ![App license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)
-![App version](https://img.shields.io/badge/version-1.0.1-blue.svg)
+![App version](https://img.shields.io/badge/version-1.0.2-blue.svg)
 
 A Node.js wrapper for Terraform's command line interface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "node-terraform-cli-wrapper",
-  "version": "1.0.0",
+  "name": "ntcw",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
       "version": "14.14.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.19.tgz",
-      "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ=="
+      "integrity": "sha512-4nhBPStMK04rruRVtVc6cDqhu7S9GZai0fpXgPXrFpcPX6Xul8xnrjSdGB4KPBVYG/R5+fXWdCM8qBoiULWGPQ==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntcw",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Node.js wrapper for Terraform's command-line interface.",
   "main": "src/index.js",
   "scripts": {
@@ -21,13 +21,14 @@
     "url": "https://github.com/bulletinmybeard/ntcw/issues"
   },
   "homepage": "https://github.com/bulletinmybeard/ntcw#readme",
-  "dependencies": {
-    "@types/node": "^14.14.19"
-  },
+  "dependencies": {},
   "bin": {
     "ntcw": "src/index.js"
   },
   "engines": {
     "node": "13.13.0"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.19"
   }
 }


### PR DESCRIPTION
- `CHANGELOG` updated
- `@types/node` moved from `dependencies` to `devDependencies`